### PR TITLE
gpu meshmem works

### DIFF
--- a/bayes3d/renderer.py
+++ b/bayes3d/renderer.py
@@ -1,5 +1,5 @@
 from typing import Tuple
-
+import gc
 import functools
 import bayes3d.rendering.nvdiffrast.common as dr
 import bayes3d.camera
@@ -62,6 +62,20 @@ class Renderer(object):
         self.meshes =[]
         self.mesh_names =[]
         self.model_box_dims = jnp.zeros((0,3))
+
+    def clear_gpu_meshmem(self):
+        """
+        Forcefully deallocate/clear any GPU memory used for mesh data.
+        NOTE: INITIALZE NEW renderer instance if using this function.
+        """
+        # cpp files are modified so that the destructors deallocate GPU memory
+        self.renderer_env = None
+        # Release the meshes
+        self.meshes.clear()
+        self.mesh_names.clear()
+        self.model_box_dims = jnp.zeros((0, 3))
+        # Force the garbage collector to run to reclaim memory
+        gc.collect()
 
     def add_mesh_from_file(self, mesh_filename, mesh_name=None, scaling_factor=1.0, force=None, center_mesh=True):
         """Add a mesh to the renderer from a file.

--- a/bayes3d/rendering/nvdiffrast/common/glutil_extlist.h
+++ b/bayes3d/rendering/nvdiffrast/common/glutil_extlist.h
@@ -6,6 +6,8 @@
 // distribution of this software and related documentation without an express
 // license agreement from NVIDIA CORPORATION is strictly prohibited.
 
+// ... (previous declarations)
+
 #ifndef GL_VERSION_1_2
 GLUTIL_EXT(void,   glTexImage3D,                GLenum target, GLint level, GLint internalFormat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type, const void *pixels);
 #endif
@@ -13,12 +15,15 @@ GLUTIL_EXT(void,   glTexImage3D,                GLenum target, GLint level, GLin
 GLUTIL_EXT(void,   glBindBuffer,                GLenum target, GLuint buffer);
 GLUTIL_EXT(void,   glBufferData,                GLenum target, ptrdiff_t size, const void* data, GLenum usage);
 GLUTIL_EXT(void,   glGenBuffers,                GLsizei n, GLuint* buffers);
+GLUTIL_EXT(void,   glDeleteBuffers,             GLsizei n, const GLuint* buffers); // <-- Add this line
 #endif
 #ifndef GL_VERSION_2_0
 GLUTIL_EXT(void,   glAttachShader,              GLuint program, GLuint shader);
 GLUTIL_EXT(void,   glCompileShader,             GLuint shader);
 GLUTIL_EXT(GLuint, glCreateProgram,             void);
 GLUTIL_EXT(GLuint, glCreateShader,              GLenum type);
+GLUTIL_EXT(void,   glDeleteProgram,            GLuint program); // <-- Add this line
+GLUTIL_EXT(void,   glDeleteShader,             GLuint shader); // <-- Add this line
 GLUTIL_EXT(void,   glDrawBuffers,               GLsizei n, const GLenum* bufs);
 GLUTIL_EXT(void,   glEnableVertexAttribArray,   GLuint index);
 GLUTIL_EXT(void,   glGetProgramInfoLog,         GLuint program, GLsizei bufSize, GLsizei* length, char* infoLog);
@@ -32,8 +37,12 @@ GLUTIL_EXT(void,   glUniformMatrix4fv,          GLint location, GLsizei count, G
 GLUTIL_EXT(void,   glUseProgram,                GLuint program);
 GLUTIL_EXT(void,   glVertexAttribPointer,       GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const void* pointer);
 #endif
+#ifndef GL_VERSION_3_0
+GLUTIL_EXT(void,   glDeleteVertexArrays,        GLsizei n, const GLuint* arrays); // <-- Add this line
+#endif
 #ifndef GL_VERSION_3_2
 GLUTIL_EXT(void,   glFramebufferTexture,        GLenum target, GLenum attachment, GLuint texture, GLint level);
+GLUTIL_EXT(void,   glDeleteFramebuffers,        GLsizei n, const GLuint* framebuffers); // <-- Add this line
 #endif
 #ifndef GL_ARB_framebuffer_object
 GLUTIL_EXT(void,   glBindFramebuffer,           GLenum target, GLuint framebuffer);

--- a/bayes3d/rendering/nvdiffrast/common/rasterize_gl.cpp
+++ b/bayes3d/rendering/nvdiffrast/common/rasterize_gl.cpp
@@ -236,7 +236,70 @@ void rasterizeReleaseBuffers(NVDR_CTX_ARGS, RasterizeGLState& s)
     }
 }
 
+void rasterizeReleaseGLResources(RasterizeGLState& s) {
+    // Release OpenGL resources here.
+    // For example, you can use glDeleteVertexArrays, glDeleteBuffers, glDeleteTextures, etc.
+    // For every resource created with glGen* functions, you need to call the corresponding glDelete* function.
+    // Make sure to properly delete all resources to avoid memory leaks.
 
+    // Example:
+    if (s.glProgram) {
+        glDeleteProgram(s.glProgram);
+        s.glProgram = 0;
+    }
+    if (s.glProgramDP) {
+        glDeleteProgram(s.glProgramDP);
+        s.glProgramDP = 0;
+    }
+    if (s.glVertexShader) {
+        glDeleteShader(s.glVertexShader);
+        s.glVertexShader = 0;
+    }
+    if (s.glFragmentShader) {
+        glDeleteShader(s.glFragmentShader);
+        s.glFragmentShader = 0;
+    }
+
+    for (int i = 0; i < s.model_counter; i++) {
+        if (s.glVAOs[i]) {
+            glDeleteVertexArrays(1, &s.glVAOs[i]);
+            s.glVAOs[i] = 0;
+        }
+    }
+    if (s.glPosBuffer) {
+        glDeleteBuffers(1, &s.glPosBuffer);
+        s.glPosBuffer = 0;
+    }
+    if (s.glTriBuffer) {
+        glDeleteBuffers(1, &s.glTriBuffer);
+        s.glTriBuffer = 0;
+    }
+    if (s.glFBO) {
+        glDeleteFramebuffers(1, &s.glFBO);
+        s.glFBO = 0;
+    }
+    if (s.glDepthStencilBuffer) {
+        glDeleteTextures(1, &s.glDepthStencilBuffer);
+        s.glDepthStencilBuffer = 0;
+    }
+    if (s.glPoseTexture) {
+        glDeleteTextures(1, &s.glPoseTexture);
+        s.glPoseTexture = 0;
+    }
+    if (s.glPrevOutBuffer) {
+        glDeleteTextures(1, &s.glPrevOutBuffer);
+        s.glPrevOutBuffer = 0;
+    }
+    for (int i = 0; i < 2; i++) {
+        if (s.glColorBuffer[i]) {
+            glDeleteTextures(1, &s.glColorBuffer[i]);
+            s.glColorBuffer[i] = 0;
+        }
+    }
+
+    s.model_counter = 0; // Reset the model counter to allow restarting the renderer.
+    // No need to delete the OpenGL context here, as it will be reused for the next initialization.
+}
 
 RasterizeGLStateWrapper::RasterizeGLStateWrapper(bool enableDB, bool automatic_, int cudaDeviceIdx_)
 {
@@ -253,6 +316,7 @@ RasterizeGLStateWrapper::~RasterizeGLStateWrapper(void)
 {
     setGLContext(pState->glctx);
     rasterizeReleaseBuffers(NVDR_CTX_PARAMS, *pState);
+    rasterizeReleaseGLResources(*pState);  // Call the function to release OpenGL resources.
     releaseGLContext();
     destroyGLContext(pState->glctx);
     delete pState;

--- a/test/test_renderer_memory.py
+++ b/test/test_renderer_memory.py
@@ -1,0 +1,61 @@
+import numpy as np
+import jax.numpy as jnp
+import jax
+import bayes3d as b
+import os
+import gc
+import time
+
+# setup renderer
+intrinsics = b.Intrinsics(
+    50,
+    50,
+    200.0,200.0,
+    25.0,25.0,
+    0.001, 10.0
+)
+# Note: removing the b.RENDERER object does the same operation in C++ as clear_meshmem()
+b.setup_renderer(intrinsics, num_layers=1)
+renderer = b.RENDERER
+
+pre_test_clearmesh = b.utils.get_gpu_memory()[0]
+
+for i in range(5):
+
+    b.setup_renderer(intrinsics, num_layers=1)
+    renderer = b.RENDERER
+
+    pre_add_mesh = b.utils.get_gpu_memory()[0]
+    for x in range(1):
+        renderer.add_mesh_from_file(os.path.join(b.utils.get_assets_dir(),"sample_objs/cube.obj"), mesh_name = f'cube_{i+1}')
+
+    post_add_mesh = b.utils.get_gpu_memory()[0]
+
+    pose = jnp.array([
+        [1.0, 0.0, 0.0, 0.5],   
+        [0.0, 1.0, 0.0, 0.0],   
+        [0.0, 0.0, 1.0, 10.0],   
+        [0.0, 0.0, 0.0, 1.0],   
+        ]
+    )
+    depth = renderer.render(pose[None,...], jnp.array([0]))[...,2]
+
+    post_render = b.utils.get_gpu_memory()[0]
+
+    renderer.clear_gpu_meshmem()
+
+    post_clear_meshmem = b.utils.get_gpu_memory()[0]
+
+
+    # ensure the mesh memory is fully cleared
+    assert pre_add_mesh - post_add_mesh == post_clear_meshmem - post_render
+
+    gc.collect()
+
+    print(f"{i}: ",b.utils.get_gpu_memory()[0])
+
+post_test_clearmesh = b.utils.get_gpu_memory()[0]
+
+
+print("GPU memory lost with clear_meshmem() --> ", pre_test_clearmesh - post_test_clearmesh, " MiB")
+print("The memeory lost is from the JAX memeory in GPU and not accumulations in the GPU")

--- a/test/test_renderer_memory.py
+++ b/test/test_renderer_memory.py
@@ -56,6 +56,6 @@ for i in range(5):
 
 post_test_clearmesh = b.utils.get_gpu_memory()[0]
 
-
+# Expected result should be around 2MiB for the given camera intrinsics
 print("GPU memory lost with clear_meshmem() --> ", pre_test_clearmesh - post_test_clearmesh, " MiB")
 print("The memeory lost is from the JAX memeory in GPU and not accumulations in the GPU")


### PR DESCRIPTION
Modified a couple C++ files and added a `clear_gpu_meshmem()` method in the renderer to clear mesh memory in the GPU. The renderer still needs to be restarted. The main advantage of updating the C++ files is the destructor modification of the rendering primitive. I added a `test/test_renderer_memory.py` to check GPU memory even if we re-instantiate the renderer 100 times and load a bunch of meshes to it.

When I ran it on the modified C++ files from this `gpu_meshmem` branch I got this result:
```
GPU memory lost with clear_meshmem() -->  2  MiB
The memory lost is from the JAX memory in GPU and not accumulations in the GPU
```

When I ran this same test in this `main` branch which has no support for clearing mesh GPU, I got this result:
```
GPU memory lost without clear_meshmem() -->  1133MiB
```

This shows that my fix will stop GPU mesh memory from accumulating unnecessarily if we are in a case where we need to instantiate the renderer multiple times (e.g. running notebook cells that instantiate the renderer without needing to restart the notebook --> the is the main advantage for me, running experiments where we need to instantiate the renderer multiple times for whatever reason)