### PR TITLE
bbox intersection check

### DIFF
--- a/bayes3d/utils/__init__.py
+++ b/bayes3d/utils/__init__.py
@@ -4,3 +4,4 @@ from .enumerations import *
 from .occlusion import *
 from .ycb_loader import *
 from .mesh import *
+from .bbox import *

--- a/bayes3d/utils/bbox.py
+++ b/bayes3d/utils/bbox.py
@@ -1,0 +1,70 @@
+import jax
+import jax.numpy as jnp
+
+def separating_axis_test(axis, box1, box2):
+    """
+    Projects both boxes onto the given axis and checks for overlap.
+    """
+    min1, max1 = project_box(axis, box1)
+    min2, max2 = project_box(axis, box2)
+
+    return jax.lax.cond(jnp.logical_or(max1 < min2, max2 < min1), lambda: False, lambda: True)
+
+    # if max1 < min2 or max2 < min1:
+    #     return False
+    # return True
+
+def project_box(axis, box):
+    """
+    Projects a box onto an axis and returns the min and max projection values.
+    """
+    corners = get_transformed_box_corners(box)
+    projections = jnp.array([jnp.dot(corner, axis) for corner in corners])
+    return jnp.min(projections), jnp.max(projections)
+
+def get_transformed_box_corners(box):
+    """
+    Returns the 8 corners of the box based on its dimensions and pose.
+    """
+    dim, pose = box
+    corners = []
+    for dx in [-dim[0]/2, dim[0]/2]:
+        for dy in [-dim[1]/2, dim[1]/2]:
+            for dz in [-dim[2]/2, dim[2]/2]:
+                corner = jnp.array([dx, dy, dz, 1])
+                transformed_corner = pose @ corner
+                corners.append(transformed_corner[:3])
+    return corners
+
+def are_bboxes_intersecting(dim1, dim2, pose1, pose2):
+    """
+    Checks if two oriented bounding boxes (OBBs), which are AABBs with poses, are intersecting using the Separating 
+    Axis Theorem (SAT).
+
+    Args:
+        dim1 (jnp.ndarray): Bounding box dimensions of first object. Shape (3,)
+        dim2 (jnp.ndarray): Bounding box dimensions of second object. Shape (3,)
+        pose1 (jnp.ndarray): Pose of first object. Shape (4,4)
+        pose2 (jnp.ndarray): Pose of second object. Shape (4,4)
+    Output:
+        Bool: Returns true if bboxes intersect
+    """
+    box1 = (dim1, pose1)
+    box2 = (dim2, pose2)
+
+    # Axes to test - the face normals of each box
+    axes_to_test = []
+    for i in range(3):  # Add the face normals of box1
+        axes_to_test.append(pose1[:3, i])
+    for i in range(3):  # Add the face normals of box2
+        axes_to_test.append(pose2[:3, i])
+
+    # Perform SAT on each axis
+    count_ = 0
+    for axis in axes_to_test:
+        count_+= jax.lax.cond(separating_axis_test(axis, box1, box2), lambda:0,lambda:-1)
+
+    return jax.lax.cond(count_ < 0, lambda:False,lambda:True)
+
+# For one reference pose (object 1) and many possible poses for the second object
+are_bboxes_intersecting_many = jax.vmap(are_bboxes_intersecting, in_axes = (None, None, None, 0))

--- a/test/test_bbox_intersect.py
+++ b/test/test_bbox_intersect.py
@@ -1,0 +1,42 @@
+import os
+import jax
+import jax.numpy as jnp
+import bayes3d as b
+
+are_bboxes_intersecting_jit = jax.jit(b.utils.are_bboxes_intersecting)
+
+# set up renderer
+intrinsics = b.Intrinsics(
+height=100,
+width=100,
+fx=250, fy=250,
+cx=100/2.0, cy=100/2.0,
+near=0.1, far=20
+)
+
+b.setup_renderer(intrinsics)
+
+b.RENDERER.add_mesh_from_file(os.path.join(b.utils.get_assets_dir(), "sample_objs/cube.obj")
+                                , scaling_factor=0.1, mesh_name = "cube_1")
+b.RENDERER.add_mesh_from_file(os.path.join(b.utils.get_assets_dir(), "sample_objs/cube.obj")
+                                , scaling_factor=0.1, mesh_name = "cube_2")
+
+# make poses intersect/collide/penetrate
+pose_1 = jnp.eye(4).at[:3,3].set([-0.1,0,1.5])
+pose_1 = pose_1 @ b.transform_from_axis_angle(jnp.array([1,0,0]), jnp.pi/4)
+pose_2 = jnp.eye(4).at[:3,3].set([-0.05,0,1.5])
+pose_2 = pose_2 @ b.transform_from_axis_angle(jnp.array([1,1,1]), jnp.pi/4)
+
+# make sure the output confirms the intersection
+b.scale_image(b.get_depth_image(b.RENDERER.render(jnp.stack([pose_1,pose_2]), jnp.array([0,1]))[:,:,2]),4).save("intersecting.png")
+is_intersecting = are_bboxes_intersecting_jit(b.RENDERER.model_box_dims[0], b.RENDERER.model_box_dims[1], pose_1, pose_2)
+assert is_intersecting == True
+
+# make poses NOT intersect/collided/penetrate
+pose_2 = jnp.eye(4).at[:3,3].set([0.04,0,1.5])
+pose_2 = pose_2 @ b.transform_from_axis_angle(jnp.array([1,1,1]), jnp.pi/4)
+
+# make sure the output confirms NO intersection
+b.scale_image(b.get_depth_image(b.RENDERER.render(jnp.stack([pose_1,pose_2]), jnp.array([0,1]))[:,:,2]),4).save("no_intersecting.png")
+is_intersecting = are_bboxes_intersecting_jit(b.RENDERER.model_box_dims[0], b.RENDERER.model_box_dims[1], pose_1, pose_2)
+assert is_intersecting == False


### PR DESCRIPTION
`b.utils.are_bboxes_intersecting` and `b.utils.are_bboxes_intersecting_many` added. These functions are jax jittable and implement the separating axis theorem algorithm. They will be useful to check for collisions or any general checking for intersections between bbox pairs and their respective poses. 

check `test/test_bbox_intersect.py` on how to use it. `b.utils.are_bboxes_intersecting_many` simply vmaps over the second pose of an object.