### PR TITLE
Add workflow dispatch trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release to Artifact Registry
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
 


### PR DESCRIPTION
This will let us manually trigger the release workflow from the Actions tab.